### PR TITLE
feature/bump release

### DIFF
--- a/.github/workflows/bump-rc.yml
+++ b/.github/workflows/bump-rc.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Open PR to release
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.PR_CREATOR_TOKEN }}
           commit-message: "bump: ${{ steps.calc.outputs.next_version }}"
           title: "bump: ${{ steps.calc.outputs.next_version }} → release"
           body: |

--- a/.github/workflows/bump-rc.yml
+++ b/.github/workflows/bump-rc.yml
@@ -83,30 +83,22 @@ jobs:
           echo "next_version=$NEXT" >> $GITHUB_OUTPUT
           echo "NEXT=$NEXT" >> $GITHUB_ENV
 
-      - name: Create bump branch and commit
+      - name: Prepare version changes
         run: |
-          BR="bump/release-${NEXT}"
-          git switch -c "$BR"
-
           jq ".version = \"${NEXT}\"" package.json > tmp && mv tmp package.json
           if [ -f package-lock.json ]; then
             jq ".version = \"${NEXT}\"" package-lock.json > tmp && mv tmp package-lock.json
-            git add package.json package-lock.json
-          else
-            git add package.json
           fi
 
-          git commit -m "bump: ${NEXT}"
-          git push -u origin "$BR"
-
       - name: Open PR to release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr create \
-            --title "bump: ${{ steps.calc.outputs.next_version }} → release" \
-            --body "자동 생성된 RC bump PR입니다.\n- version: `${{ steps.calc.outputs.next_version }}`" \
-            --base release \
-            --head bump/release-${{ steps.calc.outputs.next_version }} \
-            --label bump \
-            --label rc
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PR_CREATOR_TOKEN }}
+          commit-message: "bump: ${{ steps.calc.outputs.next_version }}"
+          title: "bump: ${{ steps.calc.outputs.next_version }} → release"
+          body: |
+            자동 생성된 RC bump PR입니다.
+            - version: `${{ steps.calc.outputs.next_version }}`
+          base: release
+          branch: bump/release-${{ steps.calc.outputs.next_version }}
+          labels: bump, rc


### PR DESCRIPTION
- **ci: PR 생성 방식을 peter-evans/create-pull-request로 복원, 본문 인용 처리 수정, PAT 시크릿 사용**
- **ci: use default GITHUB_TOKEN for create-pull-request (remove PAT)**
